### PR TITLE
Add farm productionTotal and house toggle

### DIFF
--- a/components/Farm/index.tsx
+++ b/components/Farm/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from "react";
 
 import { useAppDispatch, useAppSelector } from "hooks";
 import { FarmsType } from "libs/type";
-import { fetchFarmList, selectFarmData } from "stores/farmSlice";
+import { fetchFarmList, selectFarmData, toggleHouse } from "stores/farmSlice";
 import FarmList from "./FarmList";
 
 function sumAnnualProduction(farm: FarmsType) {
@@ -25,6 +25,7 @@ const Farm = () => {
   */
 
   const dispatch = useAppDispatch();
+
   useEffect(() => {
     dispatch(fetchFarmList());
   }, []);
@@ -36,7 +37,7 @@ const Farm = () => {
       ...farm,
       productionTotal: sumAnnualProduction(farm),
       HouseActive: (farmId: number, houseId: number) => {
-        // TODO: house 조작 함수 추가
+        dispatch(toggleHouse({ farmId, houseId }));
       },
     }));
   }, [farmData]);

--- a/stores/farmSlice.ts
+++ b/stores/farmSlice.ts
@@ -1,6 +1,6 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 
-import { RootState } from "./";
+import { RootState } from ".";
 
 interface Farm {
   id: number;
@@ -56,7 +56,16 @@ export const addFarm = createAsyncThunk(
 export const farmSlice = createSlice({
   name: "farm",
   initialState,
-  reducers: {},
+  reducers: {
+    toggleHouse: (state, action) => {
+      const { farmId, houseId } = action.payload;
+      const farm = state.data.find((farm) => farm.id === farmId);
+      const house = farm?.houses?.find((house) => house.id === houseId);
+
+      if (!house) return;
+      house.active = !house.active;
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchFarmList.pending, (state) => {
       state.loading = "pending";
@@ -78,5 +87,7 @@ export const selectFarmLoading = (state: RootState) => state.farm.loading;
 
 export const selectFarmData = (state: RootState) =>
   selectFarmDomain(state).data;
+
+export const { toggleHouse } = farmSlice.actions;
 
 export default farmSlice.reducer;


### PR DESCRIPTION
## Summary

- 각 농장 총 생산량을 보여줍니다.
- 각 농장의 하우스 별로 on/off 기능을 추가합니다. 
-  #5 

## Detail

- Farm 컴포넌트에서 farmData를 받아서 생산량 총합인 productionTotal 값을 추가 합니다.
- Farm 컴포넌트 스코프에서 HouseActive 를 생성해서 토글 함수를 전달합니다.
- farmSlice에서 해당 하우스 상태 변경하는 토글 액션을 생성합니다. 